### PR TITLE
fix: correct API endpoint path

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,7 +1,7 @@
 // src/lib/api.ts
 export async function submitLead(data: any) {
   const response = await fetch(
-    import.meta.env.VITE_BACKEND_API_URL + '/api/leads',
+    import.meta.env.VITE_BACKEND_API_URL + '/leads',
     {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary
- Corrects the API endpoint from `/api/leads` to `/leads` to match backend expectations

## Test plan
- [ ] Verify lead form submission works correctly with the corrected endpoint
- [ ] Test against local Laravel backend at `http://localhost:8000/leads`

🤖 Generated with [Claude Code](https://claude.ai/code)